### PR TITLE
feat: Add support for common ES6 features

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,16 @@ module.exports = {
 
   "ecmaFeatures": {
     "arrowFunctions": true,
+    "binaryLiterals": true,
+    "blockBindings": true,
+    "classes": true,
+    "generators": true,
+    "objectLiteralComputedProperties": true,
+    "objectLiteralDuplicateProperties": false,
+    "objectLiteralShorthandMethods": false,
+    "objectLiteralShorthandProperties": true,
+    "octalLiterals": true,
+    "spread": true,
     "templateStrings": true
   },
 


### PR DESCRIPTION
Node 4.0 supports [several ES6
features](https://nodejs.org/en/docs/es6/).
This updates linting to support those new features.

Two features are purposely disabled.

`objectLiteralDuplicateProperties` is a potential source of unexpected
bugs.

`objectLiteralShorthandMethods` appear hard to read.