### PR TITLE
chore: upgrade eslint to v2

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = {
  * Best practices
  */
     "no-extra-boolean-cast": 2,
-    "consistent-return": 2,
+    "consistent-return": 0,
     "curly": [2, "multi-line"],
     "default-case": 2,
     "dot-notation": [2, {
@@ -161,15 +161,13 @@ module.exports = {
       "before": false,
       "after": true
     }],
-    "space-before-keywords": [2, "always"],
-    "space-after-keywords": 2,
+    "keyword-spacing": 2,
     "space-before-blocks": 2,
     "space-before-function-paren": [2, {
       "anonymous": "always",
       "named": "never"
     }],
     "space-infix-ops": 2,
-    "space-return-throw-case": 2,
     "spaced-comment": 2,
     "no-multi-spaces": 0,
     "max-len": [2, 100, 2, {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "homepage": "https://github.com/meetearnest/eslint-config-earnest",
   "devDependencies": {
-    "eslint": "^1.10.2"
+    "eslint": "^2.1.0"
   },
   "peerDependencies": {
-    "eslint": "^1.10.2"
+    "eslint": "^2.1.0"
   }
 }


### PR DESCRIPTION
This commit coincides with our es7 linter's updates as well. 
See: https://github.com/meetearnest/eslint-config-earnest-es7/commit/db535d320dbfaf3dc63e29d7a35e35e1ee97df4f

@alockwood05 @jhurliman @bromanko 