### PR TITLE
Removed rule no-else-return

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,6 @@ module.exports = {
     "eqeqeq": 2,
     "guard-for-in": 2,
     "no-caller": 2,
-    "no-else-return": 2,
     "no-eq-null": 2,
     "no-eval": 2,
     "no-extend-native": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@earnest/eslint-config",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Earnest's ESLint config, following our style guide",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
 * The no else return rule can cause issues during refactoring.
 * It hides the fact of the else branch
 * It makes it difficult to write full expressions when more then two cases (ternary)